### PR TITLE
`v0.15.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/ObolNetwork/charon-k8s-distributed-validator-node.g
 cd charon-k8s-distributed-validator-node
 
 # Create your charon ENR private key, this will create a charon-enr-private-key file in the .charon directory
-docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.3 create enr
+docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.15.0 create enr
 ```
 
 You should expect to see a console output like
@@ -62,7 +62,7 @@ cp .env.create_dkg.sample .env.create_dkg
 # operator ENRs of all the operators participating in the DKG ceremony.
 
 # Run the `charon create dkg` command that generates DKG cluster-definition.json file.
-docker run --rm -v "$(pwd):/opt/charon" --env-file .env.create_dkg obolnetwork/charon:v0.14.3 create dkg
+docker run --rm -v "$(pwd):/opt/charon" --env-file .env.create_dkg obolnetwork/charon:v0.15.0 create dkg
 ```
 
 This command should output a file at `.charon/cluster-definition.json`. This file needs to be shared with the other operators in a cluster.
@@ -75,7 +75,7 @@ Every cluster member then participates in the DKG ceremony. For Charon v1, this 
 
 ```
 # Participate in DKG ceremony, this will create .charon/cluster-lock.json, .charon/deposit-data.json and .charon/validator_keys
-docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.3 dkg
+docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.15.0 dkg
 ```
 
 Assuming the DKG is successful, a number of artefacts will be created in the `.charon` folder. These include:
@@ -154,46 +154,4 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
 
 # FAQs:
 
-1. How do I get my ENR if I want to generate it again?
-
-   - `cd` to the directory where your private keys are located (ex: `cd /path/to/charon/enr/private/key`)
-   - Run `docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.3 enr`. This prints the ENR on your screen.
-   - **Please note that this ENR is not the same as the one generated when you created it for the first time**. This is because the process of generating ENRs includes the current timestamp.
-
-2. What do I do if lose my `charon-enr-private-key`?
-
-   - For now, ENR rotation/replacement is not supported, it will be supported in a future release.
-   - Therefore, it's advised to always keep a backup of your `private-key` in a secure location (ex: cloud storage, USB Flash drive etc.)
-
-3. I have run the command in `Step 1` but I can't find the keys anywhere.
-
-   - The `charon-enr-private-key` is generated inside a hidden folder `.charon`.
-   - To view it, run `ls -al` in your terminal.
-   - You can then copy the key to your `~/Downloads` folder for easy access by running `cp .charon/charon-enr-private-key ~/Downloads`. This step maybe a bit different for windows.
-   - Else, if you are on `macOS`, press `Cmd + Shift + . ` to view the `.charon` folder in the `finder` application.
-
-4. Why does Teku throw a keystore file error?
-
-   - Teku sometimes logs an error which looks like:
-     `Keystore file /opt/charon/validator_keys/keystore-0.json.lock already in use.`
-   - This can be solved by deleting the file(s) ending with `.lock` in the folder `.charon/validator_keys`.
-   - It is caused by an unsafe shut down of Teku (usually by double pressing Ctrl+C to shutdown containers faster).
-
-5. How to fix the grafana dashboard?
-
-   - Sometimes, grafana dashboard doesn't load any data first time around
-   - You can solve this by following the steps below:
-     - Click the Wheel Icon > Datasources
-     - Click prometheus
-     - Change the "Access" field from `Server (default)` to `Browser`. Press "Save & Test". It should fail.
-     - Change the "Access" field back to `Server (default)` and press "Save & Test". You should be presented with a green success icon saying "Data source is working" and you can return to the dashboard page.
-
-6. How to fix `permission denied` errors?
-
-   - Permission denied errors can come up in a variety of manners, particularly on Linux and WSL for Windows systems.
-   - In the interest of security, the charon docker image runs as a non-root user, and this user often does not have the permissions to write in the directory you have checked out the code to.
-   - This can be generally be fixed with some of the following:
-     - Running docker commands with `sudo`, if you haven't [setup docker to be run as a non-root](https://docs.docker.com/engine/install/linux-postinstall/) user.
-     - Changing the permissions of the `.charon` folder with the commands:
-       - `mkdir .charon` (if it doesn't already exist)
-       - `sudo chmod -R 666 .charon`
+See the [FAQ](https://docs.obol.tech/docs/int/faq/general) section of our docs for troubleshooting and other general inquiries.


### PR DESCRIPTION
Updates repo to `v0.15.0` release. Also, replaces the FAQ section with a link to obol docs.

category: upgrade

ticket: none 
